### PR TITLE
Update base_indexer version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'base_indexer', '>= 0.4.1'
+gem 'base_indexer', '>= 0.4.3'
 #gem 'revs-utils'
 gem 'discovery-indexer', '>= 0.9.5'
 gem 'dor-fetcher', '>= 1.1.1'
@@ -31,7 +31,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
 gem 'spring',        group: :development
 
-gem 'sprockets', '2.12.3'
+gem 'sprockets', '>= 2.12.3'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.8)
     arel (5.0.1.20140414130214)
-    base_indexer (0.4.1)
+    base_indexer (0.4.3)
       discovery-indexer (>= 0.9.5)
       is_it_working-cbeer
       rails (~> 4.1, >= 4.1.9)
@@ -234,7 +234,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  base_indexer (>= 0.4.1)
+  base_indexer (>= 0.4.3)
   capistrano (~> 3.0)
   capistrano-bundler
   capistrano-rails
@@ -255,7 +255,7 @@ DEPENDENCIES
   simplecov
   simplecov-rcov
   spring
-  sprockets (= 2.12.3)
+  sprockets (>= 2.12.3)
   sqlite3
   therubyracer
   turbolinks


### PR DESCRIPTION
To include new web service call in the base_indexer which can be used to index a collection object and all of its members into a specified configured sub-target, ignoring any release tags
