### PR TITLE
Updated nokogiri due to several vulnerabilities in libxml2 and libxslt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem 'spring',        group: :development
 
 gem 'sprockets', '>= 2.12.3'
 
+gem 'nokogiri'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     mime-types (2.6.2)
-    mini_portile (0.6.2)
+    mini_portile2 (2.0.0)
     minitest (5.8.2)
     mods (2.0.3)
       iso-639
@@ -142,8 +142,8 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (3.0.1)
     netrc (0.10.3)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.7)
+      mini_portile2 (~> 2.0.0.rc2)
     nom-xml (0.5.4)
       activesupport (>= 3.2.18)
       i18n
@@ -276,6 +276,7 @@ DEPENDENCIES
   jquery-rails
   lyberteam-capistrano-devel (~> 3)
   mysql2 (= 0.3.18)
+  nokogiri
   rails (= 4.2.3)
   responders (~> 2.0)
   rspec-rails


### PR DESCRIPTION
Got this when tried to deploy:
Vulnerabilities found!
bundle-audit --ignore '' stderr: Nothing written

SSHKit::Command::Failed: bundle-audit --ignore '' exit status: 256
bundle-audit --ignore '' stdout: Name: nokogiri
Version: 1.6.6.2
Advisory: CVE-2015-1819
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1374
Title: Nokogiri gem contains several vulnerabilities in libxml2 and libxslt
Solution: upgrade to ~> 1.6.6.4, >= 1.6.7.rc4

so updated nokogiri.

@cbeer
