### PR TITLE
No need to use file_ids for non-image objects

### DIFF
--- a/lib/sw_mapper.rb
+++ b/lib/sw_mapper.rb
@@ -169,7 +169,9 @@ class SwMapper < DiscoveryIndexer::GeneralMapper
   def file_ids
     return if purlxml.is_collection
     return purlxml.image_ids if %w(image book).include?(display_type)
-    return purlxml.file_ids if display_type == 'file'
+    # https://github.com/sul-dlss/sw-indexer-service/issues/34
+    # Only return file_ids for images, not for non-image types
+    # return purlxml.file_ids if display_type == 'file'
   end
 
   # the collection druid for items in a collection


### PR DESCRIPTION
@jkeck I left display_type in the code in case we need to revert back.  Will mark it as deprecated and pull it out of the code once the UI is tested.
