### PR TITLE
Revert "No need to use file_ids for non-image objects"

### DIFF
--- a/lib/sw_mapper.rb
+++ b/lib/sw_mapper.rb
@@ -169,9 +169,7 @@ class SwMapper < DiscoveryIndexer::GeneralMapper
   def file_ids
     return if purlxml.is_collection
     return purlxml.image_ids if %w(image book).include?(display_type)
-    # https://github.com/sul-dlss/sw-indexer-service/issues/34
-    # Only return file_ids for images, not for non-image types
-    # return purlxml.file_ids if display_type == 'file'
+    return purlxml.file_ids if display_type == 'file'
   end
 
   # the collection druid for items in a collection


### PR DESCRIPTION
Reverts sul-dlss/sw-indexer-service#45
