### PR TITLE
use pub_year_display_str to populate pub_year_ss

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'base_indexer', '>= 0.5.0'
 gem 'discovery-indexer'
 gem 'dor-fetcher', '>= 1.1.1'
-gem 'stanford-mods', '>= 1.4.0' # get new pub date methods
+gem 'stanford-mods', '>= 1.5.3' # pub_year_display_str method
 
 gem 'rails', '4.2.5.1'
 gem 'responders', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,7 @@ GEM
     sshkit (1.8.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    stanford-mods (1.5.2)
+    stanford-mods (1.5.3)
       activesupport
       mods (~> 2.0.2)
     term-ansicolor (1.3.2)
@@ -299,7 +299,7 @@ DEPENDENCIES
   spring
   sprockets (>= 2.12.3)
   sqlite3
-  stanford-mods (>= 1.4.0)
+  stanford-mods (>= 1.5.3)
   therubyracer
   turbolinks
   uglifier (>= 2.7.2)

--- a/lib/sw_mapper.rb
+++ b/lib/sw_mapper.rb
@@ -76,7 +76,7 @@ class SwMapper < DiscoveryIndexer::GeneralMapper
   # @return [Hash] Hash representing the publication fields
   def mods_to_publication_fields
     pub_year_int = modsxml.pub_year_int
-    pub_year_for_display = modsxml.pub_date_facet_single_value
+    pub_year_for_display = modsxml.pub_year_display_str
     {
       # TODO: need better implementation of pub_search in stanford-mods
       pub_search: modsxml.place,
@@ -90,7 +90,6 @@ class SwMapper < DiscoveryIndexer::GeneralMapper
       # deprecated pub_date Solr field - use pub_year_isi for sort key; pub_year_ss for display field
       #   can remove after other fields are populated for all indexing data (i.e. solrmarc, crez) and app code is changed
       pub_date: pub_year_for_display,
-      # TODO: need better stanford-mods implementation of early years (add A.D.) and vague years (1950s)
       pub_year_ss: pub_year_for_display,
 
       # TODO: need better implementation for date slider in stanford-mods (e.g. multiple years when warranted)

--- a/spec/sw_mapper_spec.rb
+++ b/spec/sw_mapper_spec.rb
@@ -8,8 +8,9 @@ describe SwMapper do
   let(:coll_pid) { 'druid:oo000oo0000' }
   let(:coll_purl_xml) { "<publicObject id='druid:oo000oo0000'></publicObject>" }
 
-  describe 'convert_to_solr_doc' do
-    it 'should properly map a digital object for SearchWorks' do
+  describe '#convert_to_solr_doc' do
+    it 'correctly maps MODS digital object to Solr doc hash' do
+      skip("test broken: it always passes regardless of what is in doc hash")
       allow(DiscoveryIndexer::InputXml::PurlxmlParserStrict).to receive(:new).with(item_pid, item_image_xml).and_return(item_purl_xml)
       allow(DiscoveryIndexer::InputXml::Modsxml).to receive(:new).with(item_pid).and_return(item_image_mods)
       mapper = SwMapper.new('zz999zz9999')
@@ -315,41 +316,54 @@ describe SwMapper do
 
   describe 'display_type' do
     it 'is the display_type from the identityMetadata if it exists' do
+      skip("need to write test")
     end
     context 'is based upon the content type if no display_type' do
       it 'is book when content type is book' do
+        skip("need to write test")
       end
       it 'is image when the content type is image, manuscript or map' do
+        skip("need to write test")
       end
       it 'is file when content type is not book, image, manuscript, or map' do
+        skip("need to write test")
       end
     end
   end
 
   describe 'file_ids' do
     it 'includes image_ids if display_type is image' do
+      skip("need to write test")
     end
     it 'includes file_ids if display_type is file' do
+      skip("need to write test")
     end
     it 'is nil if it is a collection' do
+      skip("need to write test")
     end
   end
 
   describe 'collection' do
     it 'includes collection druid if no ckey is present' do
+      skip("need to write test")
     end
     it 'includes collection ckey if ckey is present' do
+      skip("need to write test")
     end
     it 'is an empty array if no collection data is available' do
+      skip("need to write test")
     end
   end
 
   describe 'collection_with_title' do
     it 'includes collection druid with collection title if no ckey is present' do
+      skip("need to write test")
     end
     it 'includes collection ckey with collection title if ckey is present' do
+      skip("need to write test")
     end
     it 'is an empty array if no collection data available' do
+      skip("need to write test")
     end
   end
 end

--- a/spec/sw_mapper_spec.rb
+++ b/spec/sw_mapper_spec.rb
@@ -177,11 +177,11 @@ describe SwMapper do
       expect(mapper.mods_to_publication_fields[:pub_year_isi]).to eq 1666
     end
     it ':pub_date (deprecated) from Stanford::Mods::Record.pub_date_facet_single_value' do
-      expect(smods_rec).to receive(:pub_date_facet_single_value).and_return('6 B.C.')
+      expect(smods_rec).to receive(:pub_year_display_str).and_return('6 B.C.')
       expect(mapper.mods_to_publication_fields[:pub_date]).to eq '6 B.C.'
     end
-    it ':pub_year_ss from Stanford::Mods::Record.pub_date_facet_single_value' do
-      expect(smods_rec).to receive(:pub_date_facet_single_value).and_return('18th century')
+    it ':pub_year_ss from Stanford::Mods::Record.pub_year_display_str' do
+      expect(smods_rec).to receive(:pub_year_display_str).and_return('18th century')
       expect(mapper.mods_to_publication_fields[:pub_year_ss]).to eq '18th century'
     end
     it ':pub_year_tisim' do


### PR DESCRIPTION
upgrade to stanford-mods 1.5.3
connects to sul-dlss/sw-indexer-service#43 (search results piece of index BCE dates for coin collection)
connects to sul-dlss/solrmarc-sw#111 (BCE dates for coin collection)
connects to sul-dlss/SearchWorks#1140 (fix mods date display in search results)
- indexing code piece of sul-dlss/stanford-mods#56:  adds B.C. to dates before year 0, adds A.D. to dates
- indexing code piece of sul-dlss/stanford-mods#53:  nice string for decades (1950s for 195u); nice string for centuries (18th century for 17uu)
