### PR TITLE
imprint_display Solr field value from stanford_mods.imprint_display_str

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'base_indexer', '>= 0.5.0'
-gem 'discovery-indexer', '>= 1.0.0' # get constituent data from public_xml
+gem 'base_indexer', '>= 1.0.0'
 gem 'dor-fetcher', '>= 1.1.1'
-
-gem 'stanford-mods', '>= 2.0.0' # get new genre methods
 
 gem 'rails', '4.2.5.1'
 gem 'responders', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,8 +39,8 @@ GEM
     addressable (2.4.0)
     arel (6.0.3)
     ast (2.2.0)
-    base_indexer (0.6.7)
-      discovery-indexer (>= 0.10.1)
+    base_indexer (1.0.0)
+      discovery-indexer (~> 1.0.1)
       is_it_working-cbeer
       rails (~> 4.1, >= 4.1.9)
       retries
@@ -85,12 +85,12 @@ GEM
       thor (~> 0.19.1)
       tins (~> 1.6.0)
     diff-lcs (1.2.5)
-    discovery-indexer (1.0.0)
+    discovery-indexer (1.0.1)
       nokogiri
       rest-client
       retries
       rsolr
-      stanford-mods
+      stanford-mods (~> 2.1)
     dlss-capistrano (3.2.0)
       capistrano (~> 3.0)
       capistrano-bundle_audit (>= 0.0.3)
@@ -246,7 +246,7 @@ GEM
     sshkit (1.8.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    stanford-mods (2.1.0)
+    stanford-mods (2.2.0)
       activesupport
       mods (~> 2.0.2)
     term-ansicolor (1.3.2)
@@ -274,7 +274,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  base_indexer (>= 0.5.0)
+  base_indexer (>= 1.0.0)
   capistrano (~> 3.0)
   capistrano-bundler
   capistrano-passenger
@@ -282,7 +282,6 @@ DEPENDENCIES
   capistrano-rvm
   coffee-rails (~> 4.0.0)
   coveralls
-  discovery-indexer (>= 1.0.0)
   dlss-capistrano
   dor-fetcher (>= 1.1.1)
   equivalent-xml
@@ -299,7 +298,6 @@ DEPENDENCIES
   spring
   sprockets (>= 2.12.3)
   sqlite3
-  stanford-mods (>= 2.0.0)
   therubyracer
   turbolinks
   uglifier (>= 2.7.2)

--- a/lib/sw_mapper.rb
+++ b/lib/sw_mapper.rb
@@ -83,8 +83,7 @@ class SwMapper < DiscoveryIndexer::GeneralMapper
       # deprecated pub_date_sort - use pub_year_isi; pub_date_sort is a string and requires weirdness for bc dates
       #   can remove after pub_year_isi is populated for all indexing data (i.e. solrmarc, crez) and app code is changed
       pub_date_sort: modsxml.pub_year_sort_str,
-      # TODO: need better implementation of imprint_display in stanford-mods
-      imprint_display: modsxml.pub_date_display,
+      imprint_display: modsxml.imprint_display_str,
 
       # deprecated pub_date Solr field - use pub_year_isi for sort key; pub_year_ss for display field
       #   can remove after other fields are populated for all indexing data (i.e. solrmarc, crez) and app code is changed

--- a/spec/sw_mapper_spec.rb
+++ b/spec/sw_mapper_spec.rb
@@ -206,8 +206,8 @@ describe SwMapper do
       expect(mapper.mods_to_publication_fields[:pub_search]).to eq 'need pub_search impl in stanford-mods'
     end
     it ':imprint_display' do
-      expect(smods_rec).to receive(:pub_date_display).and_return('need imprint_display impl in stanford-mods')
-      expect(mapper.mods_to_publication_fields[:imprint_display]).to eq 'need imprint_display impl in stanford-mods'
+      expect(smods_rec).to receive(:imprint_display_str).and_return('imprint_display_str from stanford-mods')
+      expect(mapper.mods_to_publication_fields[:imprint_display]).to eq 'imprint_display_str from stanford-mods'
     end
   end
 


### PR DESCRIPTION
also required dependency update.   

connects to sul-dlss/solrmarc-sw#111 (BCE dates for Roman coins)
connected to sul-dlss/SearchWorks#1140 (fix MODS date display in search results)

@lmcglohon 
