### PR TITLE
Update versions for base and discovery indexer gems and remove prepending

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'base_indexer', '>= 1.0.0'
+gem 'base_indexer', '>= 2.0.0'
 gem 'dor-fetcher', '>= 1.1.1'
 
 gem 'rails', '4.2.5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,10 +39,10 @@ GEM
     addressable (2.4.0)
     arel (6.0.3)
     ast (2.2.0)
-    base_indexer (1.0.0)
-      discovery-indexer (~> 1.0.1)
+    base_indexer (2.0.0)
+      discovery-indexer (~> 2.0.0)
       is_it_working-cbeer
-      rails (~> 4.1, >= 4.1.9)
+      rails (~> 4)
       retries
     builder (3.2.2)
     bundler-audit (0.4.0)
@@ -77,15 +77,14 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
-    coveralls (0.8.10)
+    coveralls (0.8.11)
       json (~> 1.8)
-      rest-client (>= 1.6.8, < 2)
       simplecov (~> 0.11.0)
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
       tins (~> 1.6.0)
     diff-lcs (1.2.5)
-    discovery-indexer (1.0.1)
+    discovery-indexer (2.0.0)
       nokogiri
       rest-client
       retries
@@ -97,7 +96,7 @@ GEM
       capistrano-one_time_key
       capistrano-releaseboard
     docile (1.1.5)
-    domain_name (0.5.20160128)
+    domain_name (0.5.20160216)
       unf (>= 0.0.5, < 1.0.0)
     dor-fetcher (1.1.7)
       addressable
@@ -129,7 +128,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mime-types (2.99)
+    mime-types (2.99.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     mods (2.0.3)
@@ -191,9 +190,9 @@ GEM
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     retries (0.0.5)
-    rsolr (1.0.13)
+    rsolr (1.1.1)
       builder (>= 2.1.2)
-    rspec-core (3.4.2)
+    rspec-core (3.4.3)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -232,7 +231,7 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    spring (1.6.3)
+    spring (1.6.4)
     sprockets (2.12.4)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -274,7 +273,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  base_indexer (>= 1.0.0)
+  base_indexer (>= 2.0.0)
   capistrano (~> 3.0)
   capistrano-bundler
   capistrano-passenger

--- a/lib/sw_mapper.rb
+++ b/lib/sw_mapper.rb
@@ -149,13 +149,11 @@ class SwMapper < DiscoveryIndexer::GeneralMapper
 
   # the @id attribute of resource/file elements that match the dor_content_type
   # value is used to tell SearchWorks UI app of specific display needs for objects
-  # The SearchWorks app only wants image ids and needs the corresponding druid
-  # and %2F pre-prended to the file_id
-  # @return [Array<String>] filenames
+  # The SearchWorks app only wants first image id which comes from purl_model.sw_image_ids
+  # @return [String] filename
   def file_ids
     return if purlxml.is_collection
-    filename = purlxml.image_ids.first if %w(book image manuscript map webarchive-seed).include?(purlxml.dor_content_type)
-    return filename.prepend("#{druid}%2F") unless filename.nil?
+    purlxml.sw_image_ids.first if %w(book image manuscript map webarchive-seed).include?(purlxml.dor_content_type)
   end
 
   # the ids of objects of which this object is a collection member

--- a/spec/sw_mapper_spec.rb
+++ b/spec/sw_mapper_spec.rb
@@ -343,13 +343,13 @@ describe SwMapper do
 
   describe '#file_ids' do
     let(:fake_druid) { 'zz999zz9999' }
-    let(:purl_xml_model) { double('DiscoveryIndexer::InputXml::PurlxmlModel').as_null_object }
+    let(:purl_xml_model) { DiscoveryIndexer::InputXml::PurlxmlModel.new }
     let(:mapper) { described_class.new(fake_druid) }
-    it 'includes image_ids with druid and %2F pre-prended if dor_content_type is book, image, manuscript, or map' do
+    it 'is populated with the first image_id only if dor_content_type is book, image, manuscript, map, or webarchive-seed' do
       allow(purl_xml_model).to receive(:is_collection).and_return(false)
+      allow(purl_xml_model).to receive(:sw_image_ids).and_return(['zz999zz9999%2Fa24.jp2', 'zz999zz9999%2Fthumb.jp2'])
       allow(mapper).to receive(:purlxml).and_return(purl_xml_model)
       %w(book image manuscript map webarchive-seed).each { |type|
-        allow(purl_xml_model).to receive(:image_ids).and_return(['a24.jp2', 'thumb.jp2'])
         allow(purl_xml_model).to receive(:dor_content_type).and_return(type)
         expect(mapper.send(:file_ids)).to eq 'zz999zz9999%2Fa24.jp2'
       }


### PR DESCRIPTION
of druid and %2F because it is now happening in the discovery indexer purl model.
