### PR TITLE
add OkComputer checks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'config'
 
 gem 'honeybadger', '~> 2.0'
+gem 'okcomputer' # for monitoring
 
 gem 'rubocop', group: [:development, :test]
 gem 'rubocop-rspec', group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,7 @@ GEM
       activesupport (>= 3.2.18)
       i18n
       nokogiri
+    okcomputer (1.11.1)
     parser (2.3.1.2)
       ast (~> 2.2)
     pkg-config (1.1.7)
@@ -269,6 +270,7 @@ DEPENDENCIES
   equivalent-xml
   honeybadger (~> 2.0)
   jbuilder (~> 2.0)
+  okcomputer
   rails (~> 4.2)
   responders (~> 2.0)
   rspec-rails

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,47 @@
+require 'okcomputer'
+require 'uri'
+
+OkComputer.mount_at = 'status' # use /status or /status/all or /status/<name-of-check>
+OkComputer.check_in_parallel = true
+OkComputer::Registry.deregister 'database'
+
+##
+# REQUIRED checks
+
+# Simple echo of the VERSION file
+class VersionCheck < OkComputer::AppVersionCheck
+  def version
+    File.read(Rails.root.join('VERSION')).chomp
+  rescue Errno::ENOENT
+    raise UnknownRevision
+  end
+end
+OkComputer::Registry.register 'version', VersionCheck.new
+
+# Check each Solr target to see whether it's alive
+class TargetsCheck < OkComputer::Check
+  def targets
+    # TODO: the solr.yml configuration does NOT get initialized until `after_initialize`
+    # i.e., until all initializers are run. So we have to do a lazy evaluation here
+    @targets ||= BaseIndexer.solr_configuration_class_name.constantize.instance.get_configuration_hash
+    raise "OkComputer: Targets not configured" unless @targets.present?
+    @targets
+  end
+
+  def check
+    message = ""
+    targets.each_pair do |k, v|
+      check = OkComputer::HttpCheck.new(URI.parse(v['url']).to_s)
+      check.check
+      if check.success?
+        message += "Target #{k} is up. "
+      else
+        mark_failure
+        message += "Target #{k} is down. "
+      end
+    end
+    mark_message message
+  end
+end
+
+OkComputer::Registry.register 'targets', TargetsCheck.new


### PR DESCRIPTION
This PR fixes #87. Note that the following check endpoints are available:
- `/status` checks only that the server is alive
- `/status/targets` checks the all the targets in `config/solr.yml` are alive
- `/status/all` checks both
