### PR TITLE
Send deletes over for items that should be catkey checked

### DIFF
--- a/lib/sw_indexer_engine.rb
+++ b/lib/sw_indexer_engine.rb
@@ -10,13 +10,14 @@ class SwIndexerEngine < BaseIndexer::MainIndexerEngine
 
     targets ||= {}
 
-    # If a catkey exists in the purl_model, stop processing the druid and leave
-    # the method because access to the digital object will be provided by an 856
-    # in the corresponding MARC record
+    ##
+    # When a target is not in SKIP_CATKEY_CHECK and its true, check the catkey
+    # If there is a catkey, set false so that the target gets a delete message.
+    # We do this so that the "dor" index doesn't get docs indexed that are
+    # already coming from the marc record.
     targets.each do |target_key, target_value|
-      if target_value == true && !Settings.SKIP_CATKEY_CHECK.include?(target_key)
-        return nil if purl_model(druid).catkey.present?
-      end
+      next unless target_value == true && !Settings.SKIP_CATKEY_CHECK.include?(target_key)
+      targets[target_key] = false if purl_model(druid).catkey.present?
     end
 
     # Create the solr document for indexing using the Searchworks mapper and the

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,13 +1,21 @@
 ##
 # Helper methods used for tests
 module Helpers
+  def stub_solr
+    stub_request(:post, /solr/)
+      .to_return(status: 200, body: '')
+  end
+
   def stub_purl_and_solr(druid, purl_xml, mods_xml)
+    stub_purl(druid, purl_xml, mods_xml)
+    stub_solr
+  end
+
+  def stub_purl(druid, purl_xml, mods_xml)
     stub_request(:get, "https://purl.stanford.edu/#{druid}.xml")
       .to_return(status: 200, body: purl_xml)
     stub_request(:get, "https://purl.stanford.edu/#{druid}.mods")
       .to_return(status: 200, body: mods_xml)
-    stub_request(:post, /solr/)
-      .to_return(status: 200, body: '')
   end
 
   def stub_collection(druid, coll_xml)

--- a/spec/sw_indexer_engine_spec.rb
+++ b/spec/sw_indexer_engine_spec.rb
@@ -9,9 +9,15 @@ describe SwIndexerEngine do
 
   describe 'index' do
     context 'for targets that should not be skipped checking' do
-      it 'returns nil if there is a catkey present' do
+      it 'calls solr delete for the index' do
         expect(subject).to receive(:purl_model).with(item_pid).and_return(ckey_doc)
-        expect(subject.index(item_pid, 'NOTTOBESKIPPED' => true)).to be_nil
+        stub_purl('druid:zz999zz9999', item_image_xml, item_image_mods)
+        stub_collection('oo000oo0000', coll_image_xml)
+        solr_stub = stub_request(:post, /solr/)
+          .with(body: /^.*<delete><id>druid:zz999zz9999/)
+          .to_return(status: 200, body: '')
+        subject.index(item_pid, 'MYSOLR' => true)
+        expect(solr_stub).to have_been_requested
       end
       it 'proceeds with indexing' do
         stub_purl_and_solr('druid:zz999zz9999', item_image_xml, item_image_mods)


### PR DESCRIPTION
These items are index=true, should be catkey checked, but have a
catkey. We want to delete them so that the Marc overlord can gain
control of this object in the index.

Closes #105 
