### PR TITLE
Update okcomputer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
       activesupport (>= 3.2.18)
       i18n
       nokogiri
-    okcomputer (1.11.1)
+    okcomputer (1.13.0)
     parser (2.3.1.2)
       ast (~> 2.2)
     powerpack (0.1.1)
@@ -281,4 +281,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.12.5
+   1.13.5

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -18,15 +18,6 @@ class VersionCheck < OkComputer::AppVersionCheck
 end
 OkComputer::Registry.register 'version', VersionCheck.new
 
-# Pings a specific solr core -- assumes Solr is configured to use PingRequestHandler
-# @see https://cwiki.apache.org/confluence/display/solr/Ping
-class SolrCoreCheck < OkComputer::HttpCheck
-  # @param [String] `url` to Solr core
-  def initialize(url)
-    super(URI.parse(url + '/admin/ping').to_s)
-  end
-end
-
 # Check each Solr target to see whether it's alive
 class TargetsCheck < OkComputer::Check
   def targets
@@ -40,7 +31,7 @@ class TargetsCheck < OkComputer::Check
   def check
     message = ""
     targets.each_pair do |k, v|
-      check = SolrCoreCheck.new(v['url'])
+      check = OkComputer::SolrCheck.new(v['url'])
       check.check
       if check.success?
         message += "Target #{k} is up. "

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -44,4 +44,4 @@ class TargetsCheck < OkComputer::Check
   end
 end
 
-OkComputer::Registry.register 'targets', TargetsCheck.new
+OkComputer::Registry.register 'feature-targets', TargetsCheck.new


### PR DESCRIPTION
@eefahy This PR is connected to https://github.com/sul-dlss/discovery-indexing/issues/44. It upgrades OkComputer to 1.13. It also uses the built-in `SolrCheck` check, and renames the targets endpoint to `/status/feature-targets`
